### PR TITLE
sys-apps/nix: run configure with bash explicitly

### DIFF
--- a/sys-apps/nix/nix-2.3.16.ebuild
+++ b/sys-apps/nix/nix-2.3.16.ebuild
@@ -106,7 +106,7 @@ src_configure() {
 	# - don't disable implicitly: https://github.com/trofi/nix-guix-gentoo/issues/12
 	export ac_cv_header_aws_s3_S3Client_h=$(usex s3)
 
-	econf \
+	CONFIG_SHELL="${BROOT}/bin/bash" econf \
 		--localstatedir="${EPREFIX}"/nix/var \
 		$(use_enable gc) \
 		--with-sandbox-shell="${EPREFIX}"/usr/bin/busybox-nix-sandbox-shell

--- a/sys-apps/nix/nix-2.7.0-r2.ebuild
+++ b/sys-apps/nix/nix-2.7.0-r2.ebuild
@@ -118,7 +118,7 @@ src_configure() {
 	# - don't disable implicitly: https://github.com/trofi/nix-guix-gentoo/issues/12
 	export ac_cv_header_aws_s3_S3Client_h=$(usex s3)
 
-	econf \
+	CONFIG_SHELL="${BROOT}/bin/bash" econf \
 		--localstatedir="${EPREFIX}"/nix/var \
 		$(use_enable gc) \
 		--with-sandbox-shell="${EPREFIX}"/usr/bin/busybox-nix-sandbox-shell

--- a/sys-apps/nix/nix-2.8.0.ebuild
+++ b/sys-apps/nix/nix-2.8.0.ebuild
@@ -118,7 +118,7 @@ src_configure() {
 	# - don't disable implicitly: https://github.com/trofi/nix-guix-gentoo/issues/12
 	export ac_cv_header_aws_s3_S3Client_h=$(usex s3)
 
-	econf \
+	CONFIG_SHELL="${BROOT}/bin/bash" econf \
 		--localstatedir="${EPREFIX}"/nix/var \
 		$(use_enable gc) \
 		--with-sandbox-shell="${EPREFIX}"/usr/bin/busybox-nix-sandbox-shell

--- a/sys-apps/nix/nix-9999.ebuild
+++ b/sys-apps/nix/nix-9999.ebuild
@@ -119,7 +119,7 @@ src_configure() {
 	# - don't disable implicitly: https://github.com/trofi/nix-guix-gentoo/issues/12
 	export ac_cv_header_aws_s3_S3Client_h=$(usex s3)
 
-	econf \
+	CONFIG_SHELL="${BROOT}/bin/bash" econf \
 		--localstatedir="${EPREFIX}"/nix/var \
 		$(use_enable gc) \
 		--with-sandbox-shell="${EPREFIX}"/usr/bin/busybox-nix-sandbox-shell


### PR DESCRIPTION
Currently Nix's configure script relies on some bash-specific functionality,
causing the merge to fail when /bin/sh isn't bash. Take this assumption out of
the operation & just use bash to run configure.