### PR TITLE
sys-apps/nix: restrict libcpuid dependency to amd64-only

### DIFF
--- a/sys-apps/nix/nix-2.13.2.ebuild
+++ b/sys-apps/nix/nix-2.13.2.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	dev-cpp/gtest
 	dev-db/sqlite
 	dev-libs/editline:0=
-	dev-libs/libcpuid:0=
+	amd64? ( dev-libs/libcpuid:0= )
 	dev-libs/openssl:0=
 	>=dev-libs/boost-1.66:0=[context]
 	net-misc/curl

--- a/sys-apps/nix/nix-2.13.3.ebuild
+++ b/sys-apps/nix/nix-2.13.3.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	dev-cpp/gtest
 	dev-db/sqlite
 	dev-libs/editline:0=
-	dev-libs/libcpuid:0=
+	amd64? ( dev-libs/libcpuid:0= )
 	dev-libs/openssl:0=
 	>=dev-libs/boost-1.66:0=[context]
 	net-misc/curl

--- a/sys-apps/nix/nix-2.14.0.ebuild
+++ b/sys-apps/nix/nix-2.14.0.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	dev-cpp/gtest
 	dev-db/sqlite
 	dev-libs/editline:0=
-	dev-libs/libcpuid:0=
+	amd64? ( dev-libs/libcpuid:0= )
 	dev-libs/openssl:0=
 	>=dev-libs/boost-1.66:0=[context]
 	net-misc/curl

--- a/sys-apps/nix/nix-2.14.1.ebuild
+++ b/sys-apps/nix/nix-2.14.1.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	dev-cpp/gtest
 	dev-db/sqlite
 	dev-libs/editline:0=
-	dev-libs/libcpuid:0=
+	amd64? ( dev-libs/libcpuid:0= )
 	dev-libs/openssl:0=
 	>=dev-libs/boost-1.66:0=[context]
 	net-misc/curl


### PR DESCRIPTION
Per libcpuid's description on http://libcpuid.sourceforge.net/:

> libcpuid is a small C library for x86 CPU detection and feature extraction

libcpuid is only keyworded on amd64, which makes sense, because it's not really relevant anywhere else. It's also not needed by nix on other CPU architectures such as aarch64. Nix builds / works correctly without it on my aarch64 machines.

Departing from this specific PR, I'd eventually like to get in missing `~arm64` keywords for sys-apps/nix's dependency tree in this repo and ::gentoo. Aside from this change, it's all been working just fine on my aarch64 machines, including pulling binaries from the nixpkgs cache, building flakes from source, etc. So, hoping to chip away at that when I have time.