### PR TITLE
Hide nixbld users from sddm

### DIFF
--- a/sys-apps/nix/files/sddm-nixbld.conf
+++ b/sys-apps/nix/files/sddm-nixbld.conf
@@ -1,0 +1,3 @@
+[Users]
+HideUsers=nixbld1,nixbld2,nixbld3,nixbld4,nixbld5,nixbld6,nixbld7,nixbld8,nixbld9,nixbld10,nixbld11,nixbld12,nixbld13,nixbld14,nixbld15,nixbld16,nixbld17,nixbld18,nixbld19,nixbld20,nixbld21,nixbld22,nixbld23,nixbld24,nixbld25,nixbld26,nixbld27,nixbld28,nixbld29,nixbld30,nixbld31,nixbld32,nixbld33,nixbld34,nixbld35,nixbld36,nixbld37,nixbld38,nixbld39,nixbld40,nixbld41,nixbld42,nixbld43,nixbld44,nixbld45,nixbld46,nixbld47,nixbld48,nixbld49,nixbld50,nixbld51,nixbld52,nixbld53,nixbld54,nixbld55,nixbld56,nixbld57,nixbld58,nixbld59,nixbld60,nixbld61,nixbld62,nixbld63,nixbld64
+

--- a/sys-apps/nix/nix-2.19.2-r1.ebuild
+++ b/sys-apps/nix/nix-2.19.2-r1.ebuild
@@ -169,8 +169,8 @@ src_install() {
 
 	newinitd "${FILESDIR}"/nix-daemon.initd nix-daemon
 
-	dodir /etc/sddm.conf.d
-	insinto /etc/sddm.conf.d
+	dodir /usr/lib/sddm/sddm.conf.d
+	insinto /usr/lib/sddm/sddm.conf.d
 	newins "${FILESDIR}"/sddm-nixbld.conf 50-nixbld.conf
 
 	if ! use etc-profile; then

--- a/sys-apps/nix/nix-2.19.2-r1.ebuild
+++ b/sys-apps/nix/nix-2.19.2-r1.ebuild
@@ -1,0 +1,191 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools linux-info readme.gentoo-r1 tmpfiles toolchain-funcs
+
+DESCRIPTION="A purely functional package manager"
+HOMEPAGE="https://nixos.org/nix"
+
+SRC_URI="https://github.com/NixOS/nix/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="+etc-profile +gc doc +sodium"
+
+BDEPEND="
+	doc? ( app-text/mdbook
+		app-text/mdbook-linkcheck
+	)
+"
+# sys-apps/busybox-nix-sandbox-shell is needed for sandbox mount of /bin/sh
+RDEPEND="
+	app-arch/brotli
+	app-arch/bzip2
+	app-arch/xz-utils
+	app-misc/jq
+	app-text/lowdown-nix
+	dev-cpp/gtest
+	dev-db/sqlite
+	dev-libs/editline:0=
+	amd64? ( dev-libs/libcpuid:0= )
+	dev-libs/openssl:0=
+	>=dev-libs/boost-1.66:0=[context]
+	net-misc/curl
+	sys-apps/busybox-nix-sandbox-shell
+	sys-libs/libseccomp
+	sys-libs/zlib
+	gc? ( dev-libs/boehm-gc[cxx] )
+	doc? ( dev-libs/libxml2
+		dev-libs/libxslt
+		app-text/docbook-xsl-stylesheets
+	)
+	sodium? ( dev-libs/libsodium:0= )
+"
+# add users and groups
+RDEPEND+="
+	acct-group/nixbld
+"
+for i in {1..64}; do
+	RDEPEND+="
+		>=acct-user/nixbld${i}-1
+	"
+done
+DEPEND="${RDEPEND}
+	dev-cpp/nlohmann_json
+	dev-cpp/rapidcheck
+	>=sys-devel/bison-2.6
+	>=sys-devel/flex-2.5.35
+"
+
+# Upstream does not bundle .m4 files, extract from upstreams:
+# dev-util/pkgconfig: m4/pkg.m4
+# sys-devel/autoconf-archive: m4/ax_boost_base.m4, m4/ax_require_defined.m4
+DEPEND+="
+	sys-devel/autoconf-archive
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.10-libpaths.patch
+	"${FILESDIR}"/${PN}-2.16-no-sandbox-fallback.patch
+	"${FILESDIR}"/${PN}-2.16-no-sandbox-fallback-README.patch
+	"${FILESDIR}"/${PN}-2.19-DESTDIR.patch
+)
+
+DISABLE_AUTOFORMATTING=yes
+DOC_CONTENTS=" Quick start user guide on Gentoo:
+
+[as root] enable nix-daemon service:
+	[systemd] # systemctl enable nix-daemon && systemctl start nix-daemon
+	[openrc]  # rc-update add nix-daemon && /etc/init.d/nix-daemon start
+[as a user] relogin to get environment and profile update
+[as a user] fetch nixpkgs update:
+	\$ nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+	\$ nix-channel --update
+[as a user] install nix packages:
+	\$ nix-env -i mc
+[as a user] configure environment:
+	Somewhere in .bash_profile you might want to set
+	LOCALE_ARCHIVE=\$HOME/.nix-profile/lib/locale/locale-archive
+	but please read https://github.com/NixOS/nixpkgs/issues/21820
+
+Next steps:
+	nix package manager user manual: http://nixos.org/nix/manual/
+"
+
+pkg_pretend() {
+	# USER_NS is used to run builders in a default setting in linux:
+	#     https://nixos.wiki/wiki/Nix#Sandboxing
+	local CONFIG_CHECK="~USER_NS"
+	check_extra_config
+}
+
+src_prepare() {
+	default
+
+	eautoreconf
+
+	# rely on users settings
+	sed 's/GLOBAL_CXXFLAGS += -O3/GLOBAL_CXXFLAGS += /' -i Makefile || die
+	sed 's/GLOBAL_CXXFLAGS += -O3/GLOBAL_CXXFLAGS += /' -i perl/Makefile || die
+
+	# inject our copy of lowdown-nix
+	export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}${PKG_CONFIG_PATH:+:}${EPREFIX}/usr/$(get_libdir)/lowdown-nix/lib/pkgconfig"
+	export PATH="$PATH:${EPREFIX}/usr/$(get_libdir)/lowdown-nix/bin"
+
+	# inject rapidcheck extra includes
+	export CXXFLAGS="${CXXFLAGS} -I${EPREFIX}/usr/include/rapidcheck/extras/gtest/include"
+}
+
+src_configure() {
+	CONFIG_SHELL="${BROOT}/bin/bash" econf \
+		--localstatedir="${EPREFIX}"/nix/var \
+		$(use_enable gc) \
+		$(use_enable doc doc-gen) \
+		--with-sandbox-shell="${EPREFIX}"/usr/bin/busybox-nix-sandbox-shell
+
+	emake Makefile.config # gets generated late
+	cat >> Makefile.config <<-EOF
+	V = 1
+	CC = $(tc-getCC)
+	CXX = $(tc-getCXX)
+	EOF
+}
+
+src_compile() {
+	# Upstream does not support building without installation.
+	# Rely on src_install's DESTDIR=.
+	:
+}
+
+src_install() {
+	# TODO: emacs highlighter
+	default
+
+	readme.gentoo_create_doc
+
+	# TODO: will need a tweak for prefix
+
+	# Follow the steps of 'scripts/install-multi-user.sh:create_directories()'
+	local dir dirs=(
+		/nix
+		/nix/var
+		/nix/var/log
+		/nix/var/log/nix
+		/nix/var/log/nix/drvs
+		/nix/var/nix{,/db,/gcroots,/profiles,/temproots,/userpool,/daemon-socket}
+		/nix/var/nix/{gcroots,profiles}/per-user
+	)
+	for dir in "${dirs[@]}"; do
+		keepdir "${dir}"
+		fperms 0755 "${dir}"
+	done
+
+	keepdir             /nix/store
+	fowners root:nixbld /nix/store
+	fperms 1775         /nix/store
+
+	newinitd "${FILESDIR}"/nix-daemon.initd nix-daemon
+
+    dodir /etc/sddm.conf.d
+	insinto /etc/sddm.conf.d
+    newins "${FILESDIR}"/sddm-nixbld.conf 50-nixbld.conf
+
+	if ! use etc-profile; then
+		rm "${ED}"/etc/profile.d/nix.sh || die
+	fi
+	# nix-daemon.sh should not be used for users' profile.
+	# Only for daemon itself.
+	rm "${ED}"/etc/profile.d/nix-daemon.sh || die
+}
+
+pkg_postinst() {
+	if ! use etc-profile; then
+		ewarn "${EROOT}/etc/profile.d/nix.sh was removed (due to USE=-etc-profile)."
+	fi
+
+	readme.gentoo_print_elog
+	tmpfiles_process nix-daemon.conf
+}

--- a/sys-apps/nix/nix-2.19.2-r1.ebuild
+++ b/sys-apps/nix/nix-2.19.2-r1.ebuild
@@ -169,9 +169,9 @@ src_install() {
 
 	newinitd "${FILESDIR}"/nix-daemon.initd nix-daemon
 
-    dodir /etc/sddm.conf.d
+	dodir /etc/sddm.conf.d
 	insinto /etc/sddm.conf.d
-    newins "${FILESDIR}"/sddm-nixbld.conf 50-nixbld.conf
+	newins "${FILESDIR}"/sddm-nixbld.conf 50-nixbld.conf
 
 	if ! use etc-profile; then
 		rm "${ED}"/etc/profile.d/nix.sh || die


### PR DESCRIPTION
SDDM by default lists all users with uids between 1000 and 60000. This commit adds a config file placed in /etc/sddm.d which will instruct sddm to not display the nixbld[1-64] users.

The only change to the ebuild are commands to install the file (see at lines 172-174)
